### PR TITLE
Fix dynamic height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 volume-leaflet.json
+node_modules

--- a/index.js
+++ b/index.js
@@ -153,6 +153,7 @@ export default class LeafletMap extends Visualization {
     }).addTo(map);
     
     this.getChartElement().style.height = this.targetEl.height();
+    map.invalidateSize(true)
   };
 
   createMapDataModel(data) {

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ export default class LeafletMap extends Visualization {
         attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
     }).addTo(map);
     
-    this.getChartElement().style.height = '300px';
+    this.getChartElement().style.height = this.targetEl.height();
   };
 
   createMapDataModel(data) {


### PR DESCRIPTION
This PR changes the behaviour of `drawMapChart` so that the height of the leaflet map is not fixed to 300px. The height now inherits `targetEl` instead.

closes #8 